### PR TITLE
Load leaflet from cdnjs

### DIFF
--- a/rutas-ati.2015-09-01.html
+++ b/rutas-ati.2015-09-01.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>Rutas ATI sep-2015</title>
-    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css" />
 
     <style>
         body {
@@ -35,7 +35,7 @@
 <div id="map" style="width: 100%;"></div>
 </body>
 <script type="text/javascript" src="//code.jquery.com/jquery-2.1.4.min.js"></script>
-<script type="text/javascript" src="//cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js"></script>
 <script type="text/javascript" src="rutas-ati.2015-09-01.js"></script>
 <script type="text/javascript">
     $(document).ready(function() {


### PR DESCRIPTION
Leaflet's CDN doesn't seem to have valid HTTPS certificates. Some browsers might fail to load because of mixed HTTP/HTTPS contents.
